### PR TITLE
Allow options in path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
-- '5'
+- '7'
+- '6'
 - '4'
 deploy:
   provider: npm
@@ -15,4 +14,4 @@ deploy:
     repo: Receiptful/asset-helper
 notifications:
   slack:
-    secure: FePMmz7Z2X5wmyeAiULW57BtrjkS075JFNMNCSwLM8h7vFAMjOGpr/NIxVpr2PitQj9tH9RjQ9tYl+uRR9fHaChN0MX/V0b88KbvRMsHSzCAFNyiLS3Gz2IjbQmcFNiJajIcjiNONs1kEqo+mlGvJHCvi7VwZM/fERYZ8+Yt6wU=
+    secure: ZMYdPlp/Xk52+n5o/qG/3RYIw6An4fLsIdef9xkOt93BvZO3zxKjTX9Rl/Bs/F1OIzqpc0yiPcSPDAembC4IDkxOuD5HQEMLaEKCE57rT0OVW2y4NDA1bGoBluBCeHfCUvBY+IGN2jmwMt5bA35nB8mIipTOtDlbvxrnq6N3qpw=

--- a/README.md
+++ b/README.md
@@ -10,25 +10,31 @@ Install the module through NPM:
 
     $ npm install asset-helper --save
 
+**Requires Node 4 or above**
+
 ## Examples
 
 Include the module and create a new `AssetHelper` object:
 
 ```javascript
-var AssetHelper = require('asset-helper');
+const AssetHelper = require('asset-helper');
 
-var assetHelper = new AssetHelper();
-console.log(assetHelper.path('style/main.css')); // Will output style/main.css
+// Will output style/main.css
+const assetHelper = new AssetHelper();
+console.log(assetHelper.path('style/main.css')); 
 
-var assetHelperWithBaseUrl = new AssetHelper({
+// Will output http://www.foo.com/style/main.css
+const assetHelperWithBaseUrl = new AssetHelper({
   baseUrl: 'http://www.foo.com/'
 });
-console.log(assetHelperWithBaseUrl.path('style/main.css')); // Will output http://www.foo.com/style/main.css
+console.log(assetHelperWithBaseUrl.path('style/main.css')); 
 
-var assetHelperWithHash = new AssetHelper({
-  baseDirectory: __dirname + '/../public/'
+// Will output /style/main.css?v=3094302hdhsd9fu9023
+const assetHelperWithHash = new AssetHelper({
+  baseDirectory: __dirname + '/../public/',
+  appendHash: true
 });
-console.log(assetHelperWithHash.path('style/main.css')); // Will output /style/main.css?v=3094302hdhsd9fu9023
+console.log(assetHelperWithHash.path('style/main.css'));
 ```
 
 ## Configuration options

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ const assetHelperWithHash = new AssetHelper({
   appendHash: true
 });
 console.log(assetHelperWithHash.path('style/main.css'));
+
+// You can override configuration params on individual calls:
+// Will output /style/main.css
+console.log(assetHelperWithHash.path('style/main.css', { appendHash: false }));
 ```
 
 ## Configuration options

--- a/lib/asset-helper.js
+++ b/lib/asset-helper.js
@@ -1,50 +1,51 @@
 'use strict';
 
-var _ = require('lodash'),
-    fs = require('fs'),
-    crypto = require('crypto'),
-    NodeCache = require('node-cache');
+const fs = require('fs'),
+  crypto = require('crypto'),
+  NodeCache = require('node-cache');
 
-var cache = new NodeCache({ checkperiod: 0 });
+const cache = new NodeCache({ checkperiod: 0 });
 
-var AssetHelper = function(config) {
-  var defaultConfig = {
-    baseUrl: null,
-    baseDirectory: null,
-    appendHash: false
-  };
+class AssetHelper {
+  constructor(config) {
+    const defaultConfig = {
+      baseUrl: null,
+      baseDirectory: null,
+      appendHash: false
+    };
 
-  this.config = _.merge(defaultConfig, config);
+    this.config = Object.assign({}, defaultConfig, config);
 
-  if (this.config.appendHash && !this.config.baseDirectory) {
-    throw new Error('We need a baseDirectory to append an hash to the assets');
-  }
-};
-
-AssetHelper.prototype.path = function(filename) {
-  var resolvedUrl = filename;
-
-  if (this.config.baseUrl !== null) {
-    resolvedUrl = this.config.baseUrl + resolvedUrl;
+    if (this.config.appendHash && !this.config.baseDirectory) {
+      throw new Error('We need a baseDirectory to append an hash to the assets');
+    }
   }
 
-  if (this.config.appendHash) {
-    var hash = cache.get(filename);
+  path(filename) {
+    let resolvedUrl = filename;
 
-    if (typeof hash === 'undefined') {
-      var content = fs.readFileSync(this.config.baseDirectory + filename);
-      var shasum = crypto.createHash('md5');
-      shasum.update(content);
-
-      hash = shasum.digest('hex');
-
-      cache.set(filename, hash);
+    if (this.config.baseUrl !== null) {
+      resolvedUrl = this.config.baseUrl + resolvedUrl;
     }
 
-    resolvedUrl += '?v=' + hash;
-  }
+    if (this.config.appendHash) {
+      let hash = cache.get(filename);
 
-  return resolvedUrl;
-};
+      if (typeof hash === 'undefined') {
+        const content = fs.readFileSync(this.config.baseDirectory + filename);
+        const shasum = crypto.createHash('md5');
+        shasum.update(content);
+
+        hash = shasum.digest('hex');
+
+        cache.set(filename, hash);
+      }
+
+      resolvedUrl += '?v=' + hash;
+    }
+
+    return resolvedUrl;
+  };
+}
 
 module.exports = AssetHelper;

--- a/lib/asset-helper.js
+++ b/lib/asset-helper.js
@@ -15,29 +15,30 @@ class AssetHelper {
     };
 
     this.config = Object.assign({}, defaultConfig, config);
+    this.validate(this.config);
+  }
 
-    if (this.config.appendHash && !this.config.baseDirectory) {
+  validate(config) {
+    if (config.appendHash && !config.baseDirectory) {
       throw new Error('We need a baseDirectory to append an hash to the assets');
     }
   }
 
-  path(filename) {
-    let resolvedUrl = filename;
+  path(filename, options) {
+    const config = Object.assign({}, this.config, options || {});
+    this.validate(config);
 
-    if (this.config.baseUrl !== null) {
-      resolvedUrl = this.config.baseUrl + resolvedUrl;
+    let resolvedUrl = filename;
+    if (config.baseUrl !== null) {
+      resolvedUrl = config.baseUrl + resolvedUrl;
     }
 
-    if (this.config.appendHash) {
+    if (config.appendHash) {
       let hash = cache.get(filename);
 
       if (typeof hash === 'undefined') {
-        const content = fs.readFileSync(this.config.baseDirectory + filename);
-        const shasum = crypto.createHash('md5');
-        shasum.update(content);
-
-        hash = shasum.digest('hex');
-
+        const content = fs.readFileSync(config.baseDirectory + filename);
+        hash = crypto.createHash('md5').update(content).digest('hex');
         cache.set(filename, hash);
       }
 

--- a/package.json
+++ b/package.json
@@ -22,11 +22,10 @@
   },
   "homepage": "https://github.com/Receiptful/asset-helper",
   "devDependencies": {
-    "mocha": "^2.3.3",
-    "sinon": "^1.17.3"
+    "mocha": "^3.1.2",
+    "sinon": "^1.17.6"
   },
   "dependencies": {
-    "lodash": "^3.10.1",
-    "node-cache": "^3.0.0"
+    "node-cache": "^4.1.0"
   }
 }

--- a/test/asset-helper.js
+++ b/test/asset-helper.js
@@ -1,22 +1,18 @@
 'use strict';
 
-var AssetHelper = require('../lib/asset-helper.js'),
+const AssetHelper = require('../lib/asset-helper.js'),
   assert = require('assert'),
   sinon = require('sinon'),
   fs = require('fs');
 
-describe('asset-helper', function() {
+describe('asset-helper', () => {
 
-  var sandbox;
-  beforeEach(function() {
-    sandbox = sinon.sandbox.create();
-  });
+  let sandbox;
+  beforeEach(() => sandbox = sinon.sandbox.create());
 
-  afterEach(function() {
-    sandbox.restore();
-  });
+  afterEach(() => sandbox.restore());
 
-  it('should not accept appendHash flag without a baseDirectory', function() {
+  it('should not accept appendHash flag without a baseDirectory', () => {
     try {
       new AssetHelper({
         appendHash: true
@@ -28,36 +24,45 @@ describe('asset-helper', function() {
     throw new Error('It should not be possible to call the constructor with these arguments');
   });
 
-  describe('path', function() {
-    it('should return the full path to the media asset', function() {
-      var assetHelper = new AssetHelper({
+  it('should set a default configuration', () => {
+    const assetHelper = new AssetHelper();
+    assert.equal(assetHelper.config.appendHash, false);
+    assert.equal(assetHelper.config.baseUrl, null);
+    assert.equal(assetHelper.config.baseDirectory, null);
+  });
+
+  describe('path', () => {
+    it('should return the full path to the media asset', () => {
+      const assetHelper = new AssetHelper({
         baseUrl: 'https://media.receiptful.com/'
       });
 
       assert.equal('https://media.receiptful.com/fixtures/file', assetHelper.path('fixtures/file'));
     });
-    it('should append the md5 hash as querystring', function() {
-      var assetHelper = new AssetHelper({
+
+    it('should append the md5 hash as querystring', () => {
+      const assetHelper = new AssetHelper({
         baseDirectory: __dirname + '/',
         appendHash: true
       });
 
       assert.equal('fixtures/file?v=ed797865eeb815b19a9e87746109c7c3', assetHelper.path('fixtures/file'));
     });
-    it('should append the md5 hash as querystring with a full path', function() {
-      var assetHelper = new AssetHelper({
-        baseUrl: 'https://media.receiptful.com/',
+
+    it('should append the md5 hash as querystring with a full path', () => {
+      const assetHelper = new AssetHelper({
+        baseUrl: 'https://media.example.com/',
         baseDirectory: __dirname + '/',
         appendHash: true
       });
 
-      assert.equal('https://media.receiptful.com/fixtures/file?v=ed797865eeb815b19a9e87746109c7c3', assetHelper.path('fixtures/file'));
+      assert.equal('https://media.example.com/fixtures/file?v=ed797865eeb815b19a9e87746109c7c3', assetHelper.path('fixtures/file'));
     });
 
-    it('should not read the file contents if the hash is cached', function() {
-      var fsSpy = sandbox.spy(fs, 'readFileSync');
+    it('should not read the file contents if the hash is cached', () => {
+      const fsSpy = sandbox.spy(fs, 'readFileSync');
 
-      var assetHelper = new AssetHelper({
+      const assetHelper = new AssetHelper({
         baseUrl: 'https://media.receiptful.com/',
         baseDirectory: __dirname + '/',
         appendHash: true


### PR DESCRIPTION
This PR introduces a new feature that allows `options` in the call to `path`.

Other changes (all in the first commit):
- Update code to ES6
- Remove lodash dependency
- Update other dependencies to newer versions.